### PR TITLE
Redirect authenticated users from / to /dashboard

### DIFF
--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -1,6 +1,18 @@
-import { clerkMiddleware } from "@clerk/nextjs/server";
+import { clerkMiddleware, createRouteMatcher } from "@clerk/nextjs/server";
+import { NextResponse } from "next/server";
 
-export default clerkMiddleware();
+const isProtectedRoute = createRouteMatcher(["/dashboard(.*)"]);
+
+export default clerkMiddleware(async (auth, req) => {
+  if (isProtectedRoute(req)) {
+    await auth.protect();
+  }
+
+  const { userId } = await auth();
+  if (userId && req.nextUrl.pathname === "/") {
+    return NextResponse.redirect(new URL("/dashboard", req.url));
+  }
+});
 
 export const config = {
   matcher: [


### PR DESCRIPTION
- Add createRouteMatcher to protect all /dashboard routes
- Redirect logged-in users hitting the homepage to /dashboard

Closes #2