### PR TITLE
fix: Cancel button on Edit Workout, timezone fix, workout cards on dashboard

### DIFF
--- a/src/app/dashboard/page.tsx
+++ b/src/app/dashboard/page.tsx
@@ -8,7 +8,6 @@ import { Button } from "@/components/ui/button";
 import {
   Card,
   CardAction,
-  CardContent,
   CardDescription,
   CardHeader,
   CardTitle,
@@ -35,7 +34,7 @@ export default async function DashboardPage({
       <h1 className="mb-6 text-2xl font-bold">Dashboard</h1>
 
       <div className="mb-8">
-        <DatePicker date={date} />
+        <DatePicker dateStr={dateStr} />
       </div>
 
       <section>
@@ -52,52 +51,36 @@ export default async function DashboardPage({
           <p className="text-muted-foreground">No workouts logged for this date.</p>
         ) : (
           <div className="flex flex-col gap-3">
-            {workouts.map((workout) =>
-              workout.workoutExercises.length === 0 && !workout.completedAt ? (
-                <Card key={workout.id}>
-                  <CardHeader>
-                    {workout.name && (
-                      <CardTitle className="text-base">{workout.name}</CardTitle>
-                    )}
-                    <CardDescription>In Progress</CardDescription>
-                    <CardAction>
-                      <p className="text-xs text-muted-foreground">
-                        {format(workout.startedAt, "h:mm a")}
-                      </p>
-                    </CardAction>
-                  </CardHeader>
-                </Card>
-              ) : (
-                workout.workoutExercises.map((we) => (
-                  <Card key={we.id}>
-                    <CardHeader className="pb-2">
-                      <CardTitle className="text-base">{we.exercise.name}</CardTitle>
-                      <CardDescription>
-                        {we.sets.length} set{we.sets.length !== 1 ? "s" : ""}
-                      </CardDescription>
+            {workouts.map((workout) => {
+              const durationLabel = (() => {
+                if (!workout.completedAt) return "In Progress";
+                const mins = Math.round(
+                  (workout.completedAt.getTime() - workout.startedAt.getTime()) / 60000
+                );
+                const h = Math.floor(mins / 60);
+                const m = mins % 60;
+                if (h > 0 && m > 0) return `${h}h ${m} min`;
+                if (h > 0) return `${h}h`;
+                return `${m} min`;
+              })();
+              return (
+                <Link key={workout.id} href={`/dashboard/workout/${workout.id}`}>
+                  <Card className="cursor-pointer transition-colors hover:bg-accent/50">
+                    <CardHeader>
+                      {workout.name && (
+                        <CardTitle className="text-base">{workout.name}</CardTitle>
+                      )}
+                      <CardDescription>{durationLabel}</CardDescription>
                       <CardAction>
                         <p className="text-xs text-muted-foreground">
                           {format(workout.startedAt, "h:mm a")}
-                          {workout.completedAt && ` – ${format(workout.completedAt, "h:mm a")}`}
                         </p>
                       </CardAction>
                     </CardHeader>
-                    <CardContent>
-                      <div className="flex flex-wrap gap-2">
-                        {we.sets.map((set) => (
-                          <span
-                            key={set.id}
-                            className="rounded-md bg-muted px-2 py-1 text-sm text-muted-foreground"
-                          >
-                            {set.weight}kg × {set.reps}
-                          </span>
-                        ))}
-                      </div>
-                    </CardContent>
                   </Card>
-                ))
-              )
-            )}
+                </Link>
+              );
+            })}
           </div>
         )}
       </section>

--- a/src/app/dashboard/workout/[workoutId]/edit-workout-form.tsx
+++ b/src/app/dashboard/workout/[workoutId]/edit-workout-form.tsx
@@ -19,12 +19,14 @@ interface EditWorkoutFormProps {
   workoutId: number;
   initialName: string | null;
   initialStartedAt: Date;
+  initialDateStr: string;
 }
 
 export function EditWorkoutForm({
   workoutId,
   initialName,
   initialStartedAt,
+  initialDateStr,
 }: EditWorkoutFormProps) {
   const router = useRouter();
   const [name, setName] = useState(initialName ?? "");
@@ -46,7 +48,8 @@ export function EditWorkoutForm({
       startedAt,
     });
     if (!result?.error) {
-      router.push("/dashboard");
+      const newDateStr = format(startedAt, "yyyy-MM-dd");
+      router.push(`/dashboard?date=${newDateStr}`);
     }
   }
 
@@ -92,9 +95,16 @@ export function EditWorkoutForm({
         </div>
       </div>
 
-      <Button type="submit" className="w-fit">
-        Save Changes
-      </Button>
+      <div className="flex gap-3">
+        <Button type="submit">Save Changes</Button>
+        <Button
+          type="button"
+          variant="outline"
+          onClick={() => router.push(`/dashboard?date=${initialDateStr}`)}
+        >
+          Cancel
+        </Button>
+      </div>
     </form>
   );
 }

--- a/src/app/dashboard/workout/[workoutId]/page.tsx
+++ b/src/app/dashboard/workout/[workoutId]/page.tsx
@@ -25,6 +25,7 @@ export default async function EditWorkoutPage({
         workoutId={workout.id}
         initialName={workout.name ?? null}
         initialStartedAt={workout.startedAt}
+        initialDateStr={workout.startedAt.toISOString().slice(0, 10)}
       />
     </main>
   );

--- a/src/components/date-picker.tsx
+++ b/src/components/date-picker.tsx
@@ -12,11 +12,13 @@ import {
 } from "@/components/ui/popover";
 
 interface DatePickerProps {
-  date: Date;
+  dateStr: string;
 }
 
-export function DatePicker({ date }: DatePickerProps) {
+export function DatePicker({ dateStr }: DatePickerProps) {
   const router = useRouter();
+  const [year, month, day] = dateStr.split("-").map(Number);
+  const date = new Date(year, month - 1, day);
 
   function handleSelect(day: Date | undefined) {
     if (!day) return;


### PR DESCRIPTION
Closes #6

- Add Cancel button to Edit Workout form that navigates to `/dashboard?date=<original-workout-date>`
- Save Changes now redirects to `/dashboard?date=<new-date>` after saving
- Fix DatePicker timezone bug: accepts `dateStr: string` and parses in local timezone, fixing the off-by-one-day calendar highlight for users behind UTC
- Dashboard shows one clickable workout card per workout with name, start time, and duration or "In Progress"

Generated with [Claude Code](https://claude.ai/code)